### PR TITLE
Add persistent config storage, refactor

### DIFF
--- a/Spells/data/constants.js
+++ b/Spells/data/constants.js
@@ -1,0 +1,13 @@
+const ELDEN_RING_TOOLS_CONSTANTS =
+{
+    SPELL_COMPARER:
+    {
+        SORT_NAME: 0,
+        SORT_FP_COST: 1,
+        SORT_AR_NET: 2,
+        SORT_DAMAGE_NET: 3,
+        SORT_AR_FP_NET: 4,
+        SORT_DMG_FP: 5,
+        ATTACK_INDEX_MAX: 2,
+    }
+}

--- a/Spells/data/scalingPaths.js
+++ b/Spells/data/scalingPaths.js
@@ -1,4 +1,4 @@
-scalingPaths = {
+const scalingPaths = {
     0: [
         0,
         0.8344518907,

--- a/Spells/index.html
+++ b/Spells/index.html
@@ -1,13 +1,13 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
-	<head>
-		<title>Elden Ring Spell Comparator - by Jerp</title>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <link rel="stylesheet" type="text/css" href="styles/base.css"/>
-        <link rel="stylesheet" type="text/css" href="styles/main.css"/>
+    <head>
+        <title>Elden Ring Spell Comparator - by Jerp</title>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link rel="stylesheet" type="text/css" href="styles/base.css" />
+        <link rel="stylesheet" type="text/css" href="styles/main.css" />
         <script src="script/eldenRingEnums.js"></script>
+        <script src="data/constants.js"></script>
         <script src="data/spellSchools.js"></script>
         <script src="data/scalingPaths.js"></script>
         <script src="data/statScalingMap.js"></script>
@@ -16,25 +16,28 @@
         <script src="data/spells.js"></script>
         <script src="script/eldenRingScalingCalc.js"></script>
         <script src="script/eldenRingDamageCalc.js"></script>
-		<script src="script/spellComparer.js"></script>
+        <script src="script/PlayerConfigStorage.js"></script>
+        <script src="script/spellComparer.js"></script>
 
-		<meta property="og:title" content="Elden Ring Spell Comparator - by Jerp"/>
-		<meta property="og:description" content="Compare AR and Damage for Sorceries and Incantations."/>
-		<meta name="description" content="Compare AR and Damage for Sorceries and Incantations."/>
-		<meta property="twitter:description" content="Compare AR and Damage for Sorceries and Incantations."/>
-		<meta property="og:type" content="website"/>
-		<meta property="og:site_name" content="Jerp's Elden Ring tools"/>
-		<meta name="twitter:site" content="Jerp's Elden Ring tools"/>
-		<meta property="og:site" content="Jerp's Elden Ring tools"/>
-        <meta property="og:locale" content="en_US"/>
-	</head>
+        <meta property="og:title" content="Elden Ring Spell Comparator - by Jerp" />
+        <meta property="og:description" content="Compare AR and Damage for Sorceries and Incantations." />
+        <meta name="description" content="Compare AR and Damage for Sorceries and Incantations." />
+        <meta property="twitter:description" content="Compare AR and Damage for Sorceries and Incantations." />
+        <meta property="og:type" content="website" />
+        <meta property="og:site_name" content="Jerp's Elden Ring tools" />
+        <meta name="twitter:site" content="Jerp's Elden Ring tools" />
+        <meta property="og:site" content="Jerp's Elden Ring tools" />
+        <meta property="og:locale" content="en_US" />
+    </head>
 
-	<body onload="toolInstance.initialize();">
-
+    <body onload="toolInstance.initialize();">
         <h1>Elden Ring Spell Comparator</h1>
 
         <p class="mainDescription">Compare AR and Damage for Sorceries and Incantations.</p>
-        <p class="mainDescription"><b>Note:</b> Only offensive spells that deal damage or add AR are listed (no healing, Flame, Grant Me Strength, Terra Magicus, Frozen Armament, etc.).</p>
+        <p class="mainDescription">
+            <b>Note:</b> Only offensive spells that deal damage or add AR are listed (no healing, Flame, Grant Me
+            Strength, Terra Magicus, Frozen Armament, etc.).
+        </p>
         <p class="mainDescription">(Only shows spells that can be cast with current stats).</p>
 
         <div id="contentBody">
@@ -43,23 +46,40 @@
                 <table class="statsTable">
                     <tr>
                         <td>Strength</td>
-                        <td class="colStatLevelInput"><input id="statControl0" onfocus="this.select();" type="number" value="10" min="1" max="99"></input></td>
+                        <td class="colStatLevelInput">
+                            <input id="strength" onfocus="this.select();" type="number" value="10" min="1" max="99" />
+                        </td>
                     </tr>
                     <tr>
                         <td>Dexterity</td>
-                        <td class="colStatLevelInput"><input id="statControl1" onfocus="this.select();" type="number" value="10" min="1" max="99"></input></td>
+                        <td class="colStatLevelInput">
+                            <input id="dexterity" onfocus="this.select();" type="number" value="10" min="1" max="99" />
+                        </td>
                     </tr>
                     <tr>
                         <td>Intelligence</td>
-                        <td class="colStatLevelInput"><input id="statControl2" onfocus="this.select();" type="number" value="80" min="1" max="99"></input></td>
+                        <td class="colStatLevelInput">
+                            <input
+                                id="intelligence"
+                                onfocus="this.select();"
+                                type="number"
+                                value="80"
+                                min="1"
+                                max="99"
+                            />
+                        </td>
                     </tr>
                     <tr>
                         <td>Faith</td>
-                        <td class="colStatLevelInput"><input id="statControl3" onfocus="this.select();" type="number" value="50" min="1" max="99"></input></td>
+                        <td class="colStatLevelInput">
+                            <input id="faith" onfocus="this.select();" type="number" value="50" min="1" max="99" />
+                        </td>
                     </tr>
                     <tr>
                         <td>Arcane</td>
-                        <td class="colStatLevelInput"><input id="statControl4" onfocus="this.select();" type="number" value="18" min="1" max="99"></input></td>
+                        <td class="colStatLevelInput">
+                            <input id="arcane" onfocus="this.select();" type="number" value="18" min="1" max="99" />
+                        </td>
                     </tr>
                 </table>
             </div>
@@ -69,25 +89,41 @@
                 <table class="statsTable">
                     <tr>
                         <td>Regular</td>
-                        <td colspan="2" class="colStatLevelInput"><input id="upgradeControl0" onfocus="this.select();" type="number" value="25" min="0" max="25"></input></td>
+                        <td colspan="2" class="colStatLevelInput">
+                            <input
+                                id="upgradeControl0"
+                                onfocus="this.select();"
+                                type="number"
+                                value="25"
+                                min="0"
+                                max="25"
+                            />
+                        </td>
                     </tr>
                     <tr>
                         <td>Somber</td>
-                        <td colspan="2" class="colStatLevelInput"><input id="upgradeControl1" onfocus="this.select();" type="number" value="10" min="0" max="10"></input></td>
+                        <td colspan="2" class="colStatLevelInput">
+                            <input
+                                id="upgradeControl1"
+                                onfocus="this.select();"
+                                type="number"
+                                value="10"
+                                min="0"
+                                max="10"
+                            />
+                        </td>
                     </tr>
                     <tr>
                         <td>Staff</td>
                         <td class="colSelectionInput">
-                            <select id="controlStaff">
-                            </select>
+                            <select id="controlStaff"></select>
                         </td>
                         <td id="scalingStaff">-</td>
                     </tr>
                     <tr>
                         <td>Seal</td>
                         <td class="colSelectionInput">
-                            <select id="controlSeal">
-                            </select>
+                            <select id="controlSeal"></select>
                         </td>
                         <td id="scalingSeal">-</td>
                     </tr>
@@ -99,41 +135,125 @@
                 <table class="statsTable" id="statTableDef">
                     <thead>
                         <tr>
-                            <th>
-                                Type
-                            </th>
-                            <th>
-                                Defense
-                            </th>
-                            <th>
-                                Negation
-                            </th>
+                            <th>Type</th>
+                            <th>Defense</th>
+                            <th>Negation</th>
                         </tr>
                     </thead>
                     <tr>
                         <td>Phyiscal</td>
-                        <td class="colStatLevelInput"><input id="statControlDefense0" onfocus="this.select();" type="number" value="90" min="1" max="250"></input></td>
-                        <td class="colStatLevelInput"><input id="statControlNegation0" onfocus="this.select();" type="number" value="10.00" min="0" max="99"></input></td>
+                        <td class="colStatLevelInput">
+                            <input
+                                id="statControlDefense0"
+                                onfocus="this.select();"
+                                type="number"
+                                value="90"
+                                min="1"
+                                max="250"
+                            />
+                        </td>
+                        <td class="colStatLevelInput">
+                            <input
+                                id="statControlNegation0"
+                                onfocus="this.select();"
+                                type="number"
+                                value="10.00"
+                                min="0"
+                                max="99"
+                            />
+                        </td>
                     </tr>
                     <tr>
                         <td>Magic</td>
-                        <td class="colStatLevelInput"><input id="statControlDefense1" onfocus="this.select();" type="number" value="90" min="1" max="250"></input></td>
-                        <td class="colStatLevelInput"><input id="statControlNegation1" onfocus="this.select();" type="number" value="10.00" min="0" max="99"></input></td>
+                        <td class="colStatLevelInput">
+                            <input
+                                id="statControlDefense1"
+                                onfocus="this.select();"
+                                type="number"
+                                value="90"
+                                min="1"
+                                max="250"
+                            />
+                        </td>
+                        <td class="colStatLevelInput">
+                            <input
+                                id="statControlNegation1"
+                                onfocus="this.select();"
+                                type="number"
+                                value="10.00"
+                                min="0"
+                                max="99"
+                            />
+                        </td>
                     </tr>
                     <tr>
                         <td>Fire</td>
-                        <td class="colStatLevelInput"><input id="statControlDefense2" onfocus="this.select();" type="number" value="90" min="1" max="250"></input></td>
-                        <td class="colStatLevelInput"><input id="statControlNegation2" onfocus="this.select();" type="number" value="10.00" min="0" max="99"></input></td>
+                        <td class="colStatLevelInput">
+                            <input
+                                id="statControlDefense2"
+                                onfocus="this.select();"
+                                type="number"
+                                value="90"
+                                min="1"
+                                max="250"
+                            />
+                        </td>
+                        <td class="colStatLevelInput">
+                            <input
+                                id="statControlNegation2"
+                                onfocus="this.select();"
+                                type="number"
+                                value="10.00"
+                                min="0"
+                                max="99"
+                            />
+                        </td>
                     </tr>
                     <tr>
                         <td>Lightning</td>
-                        <td class="colStatLevelInput"><input id="statControlDefense3" onfocus="this.select();" type="number" value="90" min="1" max="250"></input></td>
-                        <td class="colStatLevelInput"><input id="statControlNegation3" onfocus="this.select();" type="number" value="10.00" min="0" max="99"></input></td>
+                        <td class="colStatLevelInput">
+                            <input
+                                id="statControlDefense3"
+                                onfocus="this.select();"
+                                type="number"
+                                value="90"
+                                min="1"
+                                max="250"
+                            />
+                        </td>
+                        <td class="colStatLevelInput">
+                            <input
+                                id="statControlNegation3"
+                                onfocus="this.select();"
+                                type="number"
+                                value="10.00"
+                                min="0"
+                                max="99"
+                            />
+                        </td>
                     </tr>
                     <tr>
                         <td>Holy</td>
-                        <td class="colStatLevelInput"><input id="statControlDefense4" onfocus="this.select();" type="number" value="90" min="1" max="250"></input></td>
-                        <td class="colStatLevelInput"><input id="statControlNegation4" onfocus="this.select();" type="number" value="10.00" min="0" max="99"></input></td>
+                        <td class="colStatLevelInput">
+                            <input
+                                id="statControlDefense4"
+                                onfocus="this.select();"
+                                type="number"
+                                value="90"
+                                min="1"
+                                max="250"
+                            />
+                        </td>
+                        <td class="colStatLevelInput">
+                            <input
+                                id="statControlNegation4"
+                                onfocus="this.select();"
+                                type="number"
+                                value="10.00"
+                                min="0"
+                                max="99"
+                            />
+                        </td>
                     </tr>
                 </table>
             </div>
@@ -170,54 +290,101 @@
             <div class="controlsContainer">
                 <h2>Extra Spell Schools</h2>
 
-                <div id="schoolsContainer">
-
-                </div>
+                <div id="schoolsContainer"></div>
             </div>
-
         </div>
 
-        <div id="outputDiv">
-
-        </div>
+        <div id="outputDiv"></div>
 
         <div id="footer">
-            <p>Thanks to <a href="https://twitter.com/mrtical91">Tical</a> for helping with testing and data collection.</p>
-            <p>Based on the scaling data used by <a href="https://www.reddit.com/r/Eldenring/comments/tbco46/elden_ring_weapon_calculator/">TarnishedSpreadsheet's Weapon Calculator</a>, as well as some additional data-mined information they provided.</p>
-            <p>Damage calculation based on <a href="https://www.reddit.com/r/darksouls3/comments/4f8yy8/how_defense_and_absorption_really_work/">information posted by TalentedJuli</a>.</p>
+            <p>
+                Thanks to <a href="https://twitter.com/mrtical91">Tical</a> for helping with testing and data
+                collection.
+            </p>
+            <p>
+                Based on the scaling data used by
+                <a href="https://www.reddit.com/r/Eldenring/comments/tbco46/elden_ring_weapon_calculator/"
+                    >TarnishedSpreadsheet's Weapon Calculator</a
+                >, as well as some additional data-mined information they provided.
+            </p>
+            <p>
+                Damage calculation based on
+                <a href="https://www.reddit.com/r/darksouls3/comments/4f8yy8/how_defense_and_absorption_really_work/"
+                    >information posted by TalentedJuli</a
+                >.
+            </p>
 
             <div id="footerLinks">
                 <span>Comparator tool by <a href="https://jerp.tv">Jerp</a></span>
 
                 <a href="https://twitch.tv/jerp">
-                    <svg alt="Twitch icon" class="linkIconSVG" viewBox="-15 0 238 238" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><!-- w=0.8889230769230769h -->
-                        <path fill-rule="evenodd" fill="rgb(255, 255, 255)"
-                        d="M130.604,210.120 L91.913,210.120 L67.719,234.003 L43.541,234.003 L43.541,210.120 L0.003,210.120 L0.003,38.200 L9.675,-0.008 L207.996,-0.008 L207.996,133.720 L130.604,210.120 ZM188.658,19.095 L29.031,19.095 L29.031,157.591 L72.565,157.591 L72.565,186.241 L101.588,157.591 L154.789,157.591 L188.658,124.155 L188.658,19.095 ZM135.441,57.294 L154.789,57.294 L154.789,114.612 L135.441,114.612 L135.441,57.294 ZM82.237,57.294 L101.585,57.294 L101.585,114.612 L82.237,114.612 L82.237,57.294 Z">
+                    <svg
+                        alt="Twitch icon"
+                        class="linkIconSVG"
+                        viewBox="-15 0 238 238"
+                        xmlns="http://www.w3.org/2000/svg"
+                        xmlns:xlink="http://www.w3.org/1999/xlink"
+                    >
+                        <!-- w=0.8889230769230769h -->
+                        <path
+                            fill-rule="evenodd"
+                            fill="rgb(255, 255, 255)"
+                            d="M130.604,210.120 L91.913,210.120 L67.719,234.003 L43.541,234.003 L43.541,210.120 L0.003,210.120 L0.003,38.200 L9.675,-0.008 L207.996,-0.008 L207.996,133.720 L130.604,210.120 ZM188.658,19.095 L29.031,19.095 L29.031,157.591 L72.565,157.591 L72.565,186.241 L101.588,157.591 L154.789,157.591 L188.658,124.155 L188.658,19.095 ZM135.441,57.294 L154.789,57.294 L154.789,114.612 L135.441,114.612 L135.441,57.294 ZM82.237,57.294 L101.585,57.294 L101.585,114.612 L82.237,114.612 L82.237,57.294 Z"
+                        />
                     </svg>
                 </a>
 
                 <a href="https://youtube.com/jerpdoesgames">
-                    <svg alt="YouTube icon" class="linkIconSVG" viewBox="0 -38 240 240" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><!-- w=0.8889230769230769h -->
-                        <path fill-rule="evenodd" fill="rgb(255, 255, 255)"
-                        d="M235.975,82.193 C235.975,82.193 235.975,120.202 231.115,138.532 C228.394,148.565 220.425,156.475 210.317,159.176 C191.852,164.000 117.989,164.000 117.989,164.000 C117.989,164.000 44.321,164.000 25.661,158.984 C15.553,156.282 7.584,148.372 4.863,138.339 C0.003,120.202 0.003,82.000 0.003,82.000 C0.003,82.000 0.003,43.991 4.863,25.661 C7.584,15.628 15.748,7.525 25.661,4.824 C44.127,-0.000 117.989,-0.000 117.989,-0.000 C117.989,-0.000 191.852,-0.000 210.317,5.016 C220.425,7.718 228.394,15.628 231.115,25.661 C236.169,43.991 235.975,82.193 235.975,82.193 ZM222.496,31.158 C219.970,22.104 212.574,14.965 203.193,12.527 C186.055,8.000 117.504,8.000 117.504,8.000 C117.504,8.000 48.953,8.000 31.816,12.353 C22.615,14.791 15.039,22.104 12.513,31.158 C8.003,47.699 8.003,82.000 8.003,82.000 C8.003,82.000 8.003,116.475 12.513,132.842 C15.039,141.896 22.435,149.035 31.816,151.473 C49.134,156.000 117.504,156.000 117.504,156.000 C117.504,156.000 186.055,156.000 203.193,151.647 C212.574,149.209 219.970,142.071 222.496,133.016 C227.006,116.475 227.006,82.174 227.006,82.174 C227.006,82.174 227.186,47.699 222.496,31.158 ZM94.470,46.885 L155.892,82.000 L94.470,117.115 L94.470,46.885 Z"/>
+                    <svg
+                        alt="YouTube icon"
+                        class="linkIconSVG"
+                        viewBox="0 -38 240 240"
+                        xmlns="http://www.w3.org/2000/svg"
+                        xmlns:xlink="http://www.w3.org/1999/xlink"
+                    >
+                        <!-- w=0.8889230769230769h -->
+                        <path
+                            fill-rule="evenodd"
+                            fill="rgb(255, 255, 255)"
+                            d="M235.975,82.193 C235.975,82.193 235.975,120.202 231.115,138.532 C228.394,148.565 220.425,156.475 210.317,159.176 C191.852,164.000 117.989,164.000 117.989,164.000 C117.989,164.000 44.321,164.000 25.661,158.984 C15.553,156.282 7.584,148.372 4.863,138.339 C0.003,120.202 0.003,82.000 0.003,82.000 C0.003,82.000 0.003,43.991 4.863,25.661 C7.584,15.628 15.748,7.525 25.661,4.824 C44.127,-0.000 117.989,-0.000 117.989,-0.000 C117.989,-0.000 191.852,-0.000 210.317,5.016 C220.425,7.718 228.394,15.628 231.115,25.661 C236.169,43.991 235.975,82.193 235.975,82.193 ZM222.496,31.158 C219.970,22.104 212.574,14.965 203.193,12.527 C186.055,8.000 117.504,8.000 117.504,8.000 C117.504,8.000 48.953,8.000 31.816,12.353 C22.615,14.791 15.039,22.104 12.513,31.158 C8.003,47.699 8.003,82.000 8.003,82.000 C8.003,82.000 8.003,116.475 12.513,132.842 C15.039,141.896 22.435,149.035 31.816,151.473 C49.134,156.000 117.504,156.000 117.504,156.000 C117.504,156.000 186.055,156.000 203.193,151.647 C212.574,149.209 219.970,142.071 222.496,133.016 C227.006,116.475 227.006,82.174 227.006,82.174 C227.006,82.174 227.186,47.699 222.496,31.158 ZM94.470,46.885 L155.892,82.000 L94.470,117.115 L94.470,46.885 Z"
+                        />
                     </svg>
                 </a>
 
                 <a href="https://twitter.com/jerpdoesgames">
-                    <svg alt="Twitter icon" class="linkIconSVG" viewBox="-10 -32 238 238" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><!-- w=0.8889230769230769h -->
-                        <path fill-rule="evenodd" fill="rgb(255, 255, 255)"
-                        d="M73.591,190.001 C161.897,190.001 210.187,116.909 210.187,53.529 C210.187,51.452 210.145,49.385 210.050,47.328 C219.423,40.558 227.572,32.111 234.000,22.493 C225.397,26.311 216.140,28.884 206.430,30.044 C216.341,24.107 223.951,14.711 227.540,3.511 C218.262,9.006 207.992,13.002 197.057,15.154 C188.296,5.831 175.819,-0.001 162.013,-0.001 C135.498,-0.001 113.997,21.481 113.997,47.961 C113.997,51.726 114.419,55.386 115.243,58.897 C75.343,56.894 39.962,37.806 16.287,8.784 C12.160,15.871 9.785,24.107 9.785,32.892 C9.785,49.533 18.261,64.223 31.149,72.817 C23.274,72.575 15.875,70.413 9.405,66.817 C9.394,67.017 9.394,67.218 9.394,67.428 C9.394,90.661 25.945,110.054 47.910,114.452 C43.878,115.548 39.635,116.139 35.255,116.139 C32.162,116.139 29.154,115.834 26.230,115.274 C32.341,134.330 50.064,148.198 71.079,148.589 C54.645,161.454 33.946,169.121 11.452,169.121 C7.579,169.121 3.758,168.899 -0.000,168.457 C21.248,182.060 46.475,190.001 73.591,190.001 "/>
+                    <svg
+                        alt="Twitter icon"
+                        class="linkIconSVG"
+                        viewBox="-10 -32 238 238"
+                        xmlns="http://www.w3.org/2000/svg"
+                        xmlns:xlink="http://www.w3.org/1999/xlink"
+                    >
+                        <!-- w=0.8889230769230769h -->
+                        <path
+                            fill-rule="evenodd"
+                            fill="rgb(255, 255, 255)"
+                            d="M73.591,190.001 C161.897,190.001 210.187,116.909 210.187,53.529 C210.187,51.452 210.145,49.385 210.050,47.328 C219.423,40.558 227.572,32.111 234.000,22.493 C225.397,26.311 216.140,28.884 206.430,30.044 C216.341,24.107 223.951,14.711 227.540,3.511 C218.262,9.006 207.992,13.002 197.057,15.154 C188.296,5.831 175.819,-0.001 162.013,-0.001 C135.498,-0.001 113.997,21.481 113.997,47.961 C113.997,51.726 114.419,55.386 115.243,58.897 C75.343,56.894 39.962,37.806 16.287,8.784 C12.160,15.871 9.785,24.107 9.785,32.892 C9.785,49.533 18.261,64.223 31.149,72.817 C23.274,72.575 15.875,70.413 9.405,66.817 C9.394,67.017 9.394,67.218 9.394,67.428 C9.394,90.661 25.945,110.054 47.910,114.452 C43.878,115.548 39.635,116.139 35.255,116.139 C32.162,116.139 29.154,115.834 26.230,115.274 C32.341,134.330 50.064,148.198 71.079,148.589 C54.645,161.454 33.946,169.121 11.452,169.121 C7.579,169.121 3.758,168.899 -0.000,168.457 C21.248,182.060 46.475,190.001 73.591,190.001 "
+                        />
                     </svg>
                 </a>
 
                 <a href="https://jerp.tv/discord">
-                    <svg alt="Discord icon" class="linkIconSVG" viewBox="-21 -5 245 245" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><!-- w=0.8889230769230769h -->
-                        <path fill-rule="evenodd" fill="rgb(255, 255, 255)"
-                        d="M177.183,208.150 L163.216,195.270 L148.441,181.585 L154.559,202.860 L23.663,202.860 C10.619,202.860 0.000,192.280 0.000,179.170 L0.000,23.690 C0.000,10.580 10.619,-0.000 23.663,-0.000 L178.337,-0.000 C191.381,-0.000 202.000,10.580 202.000,23.690 L202.000,167.670 L202.000,179.170 L202.000,230.000 L177.183,208.150 ZM152.481,65.665 C135.859,53.245 120.046,53.590 120.046,53.590 L118.430,55.430 C138.053,61.410 147.171,70.035 147.171,70.035 C135.167,63.480 123.393,60.260 112.427,58.995 C104.117,58.075 96.152,58.305 89.111,59.225 C88.418,59.225 87.841,59.340 87.149,59.455 C83.109,59.800 73.297,61.295 60.946,66.700 C56.675,68.655 54.136,70.035 54.136,70.035 C54.136,70.035 63.717,60.950 84.494,54.970 L83.339,53.590 C83.339,53.590 67.526,53.245 50.904,65.665 C50.904,65.665 34.282,95.680 34.282,132.710 C34.282,132.710 43.978,149.385 69.488,150.190 C69.488,150.190 73.759,145.015 77.222,140.645 C62.562,136.275 57.022,127.075 57.022,127.075 C57.022,127.075 58.176,127.880 60.254,129.030 C60.369,129.145 60.485,129.260 60.715,129.375 C61.062,129.605 61.408,129.720 61.754,129.950 C64.640,131.560 67.526,132.825 70.181,133.860 C74.913,135.700 80.569,137.540 87.149,138.805 C95.806,140.415 105.963,140.990 117.045,138.920 C122.470,138.000 128.010,136.390 133.782,133.975 C137.822,132.480 142.323,130.295 147.056,127.190 C147.056,127.190 141.285,136.620 126.163,140.875 C129.626,145.245 133.782,150.190 133.782,150.190 C159.291,149.385 169.103,132.710 169.103,132.710 C169.103,95.680 152.481,65.665 152.481,65.665 ZM122.239,122.015 C115.775,122.015 110.465,116.265 110.465,109.250 C110.465,102.235 115.659,96.485 122.239,96.485 C128.818,96.485 134.013,102.235 134.013,109.250 C134.013,116.265 128.818,122.015 122.239,122.015 ZM80.107,122.015 C73.643,122.015 68.334,116.265 68.334,109.250 C68.334,102.235 73.528,96.485 80.107,96.485 C86.687,96.485 91.997,102.235 91.881,109.250 C91.881,116.265 86.687,122.015 80.107,122.015 Z"/>
+                    <svg
+                        alt="Discord icon"
+                        class="linkIconSVG"
+                        viewBox="-21 -5 245 245"
+                        xmlns="http://www.w3.org/2000/svg"
+                        xmlns:xlink="http://www.w3.org/1999/xlink"
+                    >
+                        <!-- w=0.8889230769230769h -->
+                        <path
+                            fill-rule="evenodd"
+                            fill="rgb(255, 255, 255)"
+                            d="M177.183,208.150 L163.216,195.270 L148.441,181.585 L154.559,202.860 L23.663,202.860 C10.619,202.860 0.000,192.280 0.000,179.170 L0.000,23.690 C0.000,10.580 10.619,-0.000 23.663,-0.000 L178.337,-0.000 C191.381,-0.000 202.000,10.580 202.000,23.690 L202.000,167.670 L202.000,179.170 L202.000,230.000 L177.183,208.150 ZM152.481,65.665 C135.859,53.245 120.046,53.590 120.046,53.590 L118.430,55.430 C138.053,61.410 147.171,70.035 147.171,70.035 C135.167,63.480 123.393,60.260 112.427,58.995 C104.117,58.075 96.152,58.305 89.111,59.225 C88.418,59.225 87.841,59.340 87.149,59.455 C83.109,59.800 73.297,61.295 60.946,66.700 C56.675,68.655 54.136,70.035 54.136,70.035 C54.136,70.035 63.717,60.950 84.494,54.970 L83.339,53.590 C83.339,53.590 67.526,53.245 50.904,65.665 C50.904,65.665 34.282,95.680 34.282,132.710 C34.282,132.710 43.978,149.385 69.488,150.190 C69.488,150.190 73.759,145.015 77.222,140.645 C62.562,136.275 57.022,127.075 57.022,127.075 C57.022,127.075 58.176,127.880 60.254,129.030 C60.369,129.145 60.485,129.260 60.715,129.375 C61.062,129.605 61.408,129.720 61.754,129.950 C64.640,131.560 67.526,132.825 70.181,133.860 C74.913,135.700 80.569,137.540 87.149,138.805 C95.806,140.415 105.963,140.990 117.045,138.920 C122.470,138.000 128.010,136.390 133.782,133.975 C137.822,132.480 142.323,130.295 147.056,127.190 C147.056,127.190 141.285,136.620 126.163,140.875 C129.626,145.245 133.782,150.190 133.782,150.190 C159.291,149.385 169.103,132.710 169.103,132.710 C169.103,95.680 152.481,65.665 152.481,65.665 ZM122.239,122.015 C115.775,122.015 110.465,116.265 110.465,109.250 C110.465,102.235 115.659,96.485 122.239,96.485 C128.818,96.485 134.013,102.235 134.013,109.250 C134.013,116.265 128.818,122.015 122.239,122.015 ZM80.107,122.015 C73.643,122.015 68.334,116.265 68.334,109.250 C68.334,102.235 73.528,96.485 80.107,96.485 C86.687,96.485 91.997,102.235 91.881,109.250 C91.881,116.265 86.687,122.015 80.107,122.015 Z"
+                        />
                     </svg>
                 </a>
             </div>
         </div>
-
-	</body>
+    </body>
 </html>

--- a/Spells/script/PlayerConfigStorage.js
+++ b/Spells/script/PlayerConfigStorage.js
@@ -1,0 +1,106 @@
+
+// Persists player stats in browser storage, meant to be shared between tools
+class PlayerConfigStorage
+{
+    static IDENTIFIER = "ELDEN_RING_TOOLS_PLAYER_CONFIG";
+    static INSTANCE = new PlayerConfigStorage();
+
+    _config = PlayerConfigStorage.getDefaultConfig();
+    _loaded = false;
+
+    static getInstance()
+    {
+        return PlayerConfigStorage.INSTANCE;
+    }
+
+    getConfig()
+    {
+        if (!this._loaded)
+        {
+            this._config = PlayerConfigStorage.loadConfiguration();
+            this._loaded = true;
+        }
+        return this._config;
+    }
+
+    setConfig(value)
+    {
+        this._config = value;
+        PlayerConfigStorage.saveConfiguration(value);
+    }
+
+    static loadConfiguration()
+    {        
+        const config = localStorage.getItem(PlayerConfigStorage.IDENTIFIER);
+        if (config != null)
+            return JSON.parse(config);
+        else
+            return PlayerConfigStorage.getDefaultConfig();
+    }
+
+    static saveConfiguration(config)
+    {
+        localStorage.setItem(PlayerConfigStorage.IDENTIFIER, JSON.stringify(config));
+    }
+
+    // This isn't used anywhere, it's just for reference and to provide type-checking
+    // (TypeScript automatically infers the type of the return value, which we want to apply to the "config" property)
+    static getDefaultConfig()
+    {
+        return {
+            selectedStaff: 0,
+            selectedSeal: 0,
+            showCharged : false,
+            weaponLevels : {
+                regular: 25,
+                somber: 10
+            },
+            damageTypes : [
+                {
+                    defense: 90,
+                    negation: 10.00
+                },
+                {
+                    defense: 90,
+                    negation: 10.00
+                },
+                {
+                    defense: 90,
+                    negation: 10.00
+                },
+                {
+                    defense: 90,
+                    negation: 10.00
+                },
+                {
+                    defense: 90,
+                    negation: 10.00
+                }
+            ],
+            sort : ELDEN_RING_TOOLS_CONSTANTS.SPELL_COMPARER.SORT_DMG_FP,
+            filter : SPELL_TYPE_ALL,
+            stats: [
+                {
+                    name: "strength",
+                    value: 10
+                },
+                {
+                    name: "dexterity",
+                    value: 10
+                },
+                {
+                    name: "intelligence",
+                    value: 80
+                },
+                {
+                    name: "faith",
+                    value: 50
+                },
+                {
+                    name: "arcane",
+                    value: 18
+                }
+            ]
+        }
+    }
+}

--- a/Spells/script/eldenRingScalingCalc.js
+++ b/Spells/script/eldenRingScalingCalc.js
@@ -18,13 +18,7 @@ class eldenRingScalingCalc
 
     static getScalingMapByID(aMapID)
     {
-        for (var i = 0; i < statScalingMap.length; i++)
-        {
-            if (statScalingMap[i].id == aMapID)
-            {
-                return statScalingMap[i];
-            }
-        }
+        return Object.values(statScalingMap).find(it => it.id == aMapID);
     }
 
     static isToolScaledByStat(aTool, aStatIndex, aDamageTypeIndex)

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -2,6 +2,7 @@
     // Enable type-checking for JavaScript
     "compilerOptions": {
       "checkJs": true,
-      "lib": ["DOM", "ES2022"]
+      "lib": ["DOM", "ES2022"],
+      "target": "ES6"
     },
   }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,7 @@
+{
+    // Enable type-checking for JavaScript
+    "compilerOptions": {
+      "checkJs": true,
+      "lib": ["DOM", "ES2022"]
+    },
+  }


### PR DESCRIPTION
Adds a new class, `PlayerConfigStorage` with a global singleton that manages serialization + de-serialization and storage of config objects

Hooks this class up to the UI so that values are initialized from it, and update + store the current configuration on every UI change

Now configuration persists between tabs and page loads

The idea is to re-use this class and it's instance with the other tools so that changes in one tool have their values shared with other tools.

IE, I use `Spell Comparer` and set my `INT` to 50, then in another tab I open `Staff/Seal Comparer` and my `INT` is preconfigured.

Bunch of misc cleanups in the JS code for simplification/best-practices, formatted the HTML with Prettier, created a `jsconfig.json` in project root so that IDE's type-check the JS using inference like it was TypeScript.